### PR TITLE
Parameterize base directory of tagent server

### DIFF
--- a/tagent/Cargo.lock
+++ b/tagent/Cargo.lock
@@ -1509,6 +1509,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "resolv-conf"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1772,6 +1781,21 @@ dependencies = [
  "futures",
  "sanitize-filename",
  "serde",
+ "tempfile",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if 1.0.0",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi 0.3.9",
 ]
 
 [[package]]

--- a/tagent/Cargo.toml
+++ b/tagent/Cargo.toml
@@ -13,6 +13,6 @@ actix-multipart = "0.3"
 futures = "0.3.5"
 async-std = "1.8.0"
 sanitize-filename = "0.3"
-
+tempfile = "3.3.0"
 
 

--- a/tagent/src/handlers.rs
+++ b/tagent/src/handlers.rs
@@ -302,7 +302,6 @@ mod test {
         }
         std::env::remove_var("HOME");
         let a = get_root_dir();
-        dbg!(&a);
         assert!(a.is_err());
         Ok(())
     }

--- a/tagent/src/main.rs
+++ b/tagent/src/main.rs
@@ -7,13 +7,13 @@ mod representations;
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
     std::env::set_var("RUST_LOG", "actix_web=debug");
-
-    HttpServer::new(|| {
+    let root_dir = handlers::get_root_dir()?;
+    HttpServer::new(move || {
         App::new()
             .data(representations::AppState {
                 app_name: String::from("tagent"),
                 app_version: String::from("0.1.0"),
-                root_dir: String::from("/home/jstubbs/projects"),
+                root_dir: String::from(&root_dir),
             })
             .service(
                 //


### PR DESCRIPTION
# Parameterize base directory of tagent server

This PR introduces the function `handlers::get_root_dir() -> Result<String>` that tries to find a convenient root directory where to base the HTTP server.

The steps it follows are:
- Use the environment variable `TAGENT_HOME`, if defined.
- Otherwise, try to get the current directory where the server is being executed.
- If the previous step fails (for example, the current directory has been deleted), then use the environment variable `HOME`.
- If all the previous steps fail, return `Err<...>`.

The PR introduces a few unit tests for this function. Note that the tests should be run sequentially, because they set and reset environment variables in the same process:
```
cargo test -- --test-threads=1
```
(A future PR may remove this restriction, by parameterizing the `get_root_dir` function with the variables to check, or even the policy to follow for defaults, etc., so it becames easier to test in isolation. It could even become its own crate.)

Clippy and fmt have been run:
```shell
tagent/tagent$ cargo clippy
    Checking tagent v0.1.0 (/Users/waltermoreira/tagent/tagent)
    Finished dev [unoptimized + debuginfo] target(s) in 0.84s

tagent/tagent$ cargo fmt --check

tagent/tagent$ echo $?
0
``` 