### PR TITLE
Add test for /status/ready endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,6 +127,7 @@ version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdf3f2183be1241ed4dd22611850b85d38de0b08a09f1f7bcccbd0809084b359"
 dependencies = [
+ "actix-macros",
  "futures-core",
  "tokio",
 ]
@@ -2034,6 +2035,7 @@ version = "0.1.0"
 dependencies = [
  "actix-files",
  "actix-multipart",
+ "actix-rt",
  "actix-web",
  "async-std",
  "dotenv",

--- a/tagent/Cargo.toml
+++ b/tagent/Cargo.toml
@@ -23,4 +23,6 @@ uuid = { version = "0.8", features = ["v4"] }
 rsa = "0.5.0"
 tempfile = "3.3.0"
 
+[dev-dependencies]
+actix-rt = "2.6.0"
 

--- a/tagent/rustfmt.toml
+++ b/tagent/rustfmt.toml
@@ -1,0 +1,1 @@
+max_width = 80

--- a/tagent/rustfmt.toml
+++ b/tagent/rustfmt.toml
@@ -1,1 +1,1 @@
-max_width = 80
+# max_width = 80

--- a/tagent/src/auth.rs
+++ b/tagent/src/auth.rs
@@ -79,11 +79,17 @@ async fn fetch_publickey(uri: &str) -> Result<String, String> {
 
 //get the value of a header_name from a request
 // cf., https://stackoverflow.com/questions/52919494/is-there-simpler-method-to-get-the-string-value-of-an-actix-web-http-header
-fn get_header_value<'a>(req: &'a HttpRequest, header_name: &str) -> Option<&'a str> {
+fn get_header_value<'a>(
+    req: &'a HttpRequest,
+    header_name: &str,
+) -> Option<&'a str> {
     req.headers().get(header_name)?.to_str().ok()
 }
 
-pub async fn get_sub(req: HttpRequest, pub_key: String) -> Result<String, String> {
+pub async fn get_sub(
+    req: HttpRequest,
+    pub_key: String,
+) -> Result<String, String> {
     debug!("top of get_sub");
     let token = get_header_value(&req, "x-tapis-token");
     debug!("returned from get_header_value..");

--- a/tagent/src/auth.rs
+++ b/tagent/src/auth.rs
@@ -79,17 +79,11 @@ async fn fetch_publickey(uri: &str) -> Result<String, String> {
 
 //get the value of a header_name from a request
 // cf., https://stackoverflow.com/questions/52919494/is-there-simpler-method-to-get-the-string-value-of-an-actix-web-http-header
-fn get_header_value<'a>(
-    req: &'a HttpRequest,
-    header_name: &str,
-) -> Option<&'a str> {
+fn get_header_value<'a>(req: &'a HttpRequest, header_name: &str) -> Option<&'a str> {
     req.headers().get(header_name)?.to_str().ok()
 }
 
-pub async fn get_sub(
-    req: HttpRequest,
-    pub_key: String,
-) -> Result<String, String> {
+pub async fn get_sub(req: HttpRequest, pub_key: String) -> Result<String, String> {
     debug!("top of get_sub");
     let token = get_header_value(&req, "x-tapis-token");
     debug!("returned from get_header_value..");

--- a/tagent/src/handlers.rs
+++ b/tagent/src/handlers.rs
@@ -315,6 +315,11 @@ pub async fn post_file_contents_path(
 
 #[cfg(test)]
 mod test {
+    use actix_web::App;
+    use reqwest::StatusCode;
+
+    use crate::make_config;
+
     use super::*;
 
     #[test]
@@ -376,6 +381,26 @@ mod test {
         std::env::remove_var("HOME");
         let a = get_root_dir();
         assert!(a.is_err());
+        Ok(())
+    }
+
+    #[actix_rt::test]
+    async fn status_should_be_ready() -> std::io::Result<()> {
+        let app_state = AppState {
+            app_version: String::from("0.1.0"),
+            root_dir: String::from(""),
+            pub_key: String::from(""),
+        };
+        let mut app = actix_web::test::init_service(
+            App::new().configure(make_config(web::Data::new(app_state))),
+        )
+        .await;
+        let req = actix_web::test::TestRequest::get()
+            .uri("/status/ready")
+            .to_request();
+        let resp =
+            actix_web::test::call_service(&mut app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
         Ok(())
     }
 }

--- a/tagent/src/handlers.rs
+++ b/tagent/src/handlers.rs
@@ -1,6 +1,7 @@
 use actix_files::NamedFile;
 use actix_web::{
-    get, post, web, Either, Error, HttpRequest, HttpResponse, Responder, ResponseError, Result,
+    get, post, web, Either, Error, HttpRequest, HttpResponse, Responder,
+    ResponseError, Result,
 };
 use log::{debug, info};
 use std::fmt;
@@ -13,7 +14,9 @@ use futures::{StreamExt, TryStreamExt};
 use uuid::Uuid;
 
 use super::auth::get_sub;
-use super::representations::{AppState, ErrorRsp, FileListingRsp, FileUploadRsp, Ready};
+use super::representations::{
+    AppState, ErrorRsp, FileListingRsp, FileUploadRsp, Ready,
+};
 
 // status endpoints ---
 #[get("/status/ready")]
@@ -64,7 +67,10 @@ pub fn path_buf_to_string(input: PathBuf) -> Option<String> {
 
 fn path_to_string(input: &Path) -> std::io::Result<String> {
     input.to_str().map(String::from).ok_or_else(|| {
-        std::io::Error::new(std::io::ErrorKind::Other, "Couldn't convert path to string")
+        std::io::Error::new(
+            std::io::ErrorKind::Other,
+            "Couldn't convert path to string",
+        )
     })
 }
 
@@ -122,7 +128,10 @@ pub async fn list_files_path(
     let subject = match subject {
         Ok(sub) => sub,
         Err(error) => {
-            let msg = format!("got an error from get_subject_of_request; error: {}", error);
+            let msg = format!(
+                "got an error from get_subject_of_request; error: {}",
+                error
+            );
             info!("{}", msg);
             let r = ErrorRsp {
                 status: String::from("error"),
@@ -191,7 +200,10 @@ impl ResponseError for TagentError {
     }
 }
 
-pub fn make_tagent_error(message: String, version: String) -> Result<(), TagentError> {
+pub fn make_tagent_error(
+    message: String,
+    version: String,
+) -> Result<(), TagentError> {
     let r = TagentError { message, version };
     Err(r)
 }
@@ -238,16 +250,20 @@ pub async fn get_file_contents_path(
     Ok(res)
 }
 
-pub async fn save_file(mut payload: Multipart, full_path: &str) -> std::io::Result<()> {
+pub async fn save_file(
+    mut payload: Multipart,
+    full_path: &str,
+) -> std::io::Result<()> {
     // cf., https://github.com/actix/examples/blob/master/forms/multipart/src/main.rs#L8
     // iterate over multipart stream
     while let Ok(Some(mut field)) = payload.try_next().await {
         // A multipart/form-data stream has to contain `content_disposition`
         let content_disposition = field.content_disposition();
 
-        let filename = content_disposition
-            .get_filename()
-            .map_or_else(|| Uuid::new_v4().to_string(), sanitize_filename::sanitize);
+        let filename = content_disposition.get_filename().map_or_else(
+            || Uuid::new_v4().to_string(),
+            sanitize_filename::sanitize,
+        );
 
         let filepath = format!("{}/{}", full_path, filename);
 
@@ -255,8 +271,9 @@ pub async fn save_file(mut payload: Multipart, full_path: &str) -> std::io::Resu
 
         // Field in turn is stream of *Bytes* object
         while let Some(chunk) = field.next().await {
-            let data =
-                chunk.map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
+            let data = chunk.map_err(|e| {
+                std::io::Error::new(std::io::ErrorKind::Other, e.to_string())
+            })?;
             f.write_all(&data).await?;
         }
     }
@@ -288,7 +305,8 @@ pub async fn post_file_contents_path(
         error = true;
     };
     if !full_path.is_dir() {
-        message = format!("Invalid path; path {:?} must be a directory", full_path);
+        message =
+            format!("Invalid path; path {:?} must be a directory", full_path);
         error = true;
     };
     if error {
@@ -370,7 +388,8 @@ mod test {
     }
 
     #[test]
-    fn get_root_dir_should_fail_if_no_vars_or_current_dir() -> std::io::Result<()> {
+    fn get_root_dir_should_fail_if_no_vars_or_current_dir(
+    ) -> std::io::Result<()> {
         std::env::remove_var("TAGENT_HOME");
         {
             let temp = tempfile::TempDir::new()?;
@@ -398,8 +417,7 @@ mod test {
         let req = actix_web::test::TestRequest::get()
             .uri("/status/ready")
             .to_request();
-        let resp =
-            actix_web::test::call_service(&mut app, req).await;
+        let resp = actix_web::test::call_service(&mut app, req).await;
         assert_eq!(resp.status(), StatusCode::OK);
         Ok(())
     }

--- a/tagent/src/handlers.rs
+++ b/tagent/src/handlers.rs
@@ -410,14 +410,14 @@ mod test {
             root_dir: String::from(""),
             pub_key: String::from(""),
         };
-        let mut app = actix_web::test::init_service(
+        let app = actix_web::test::init_service(
             App::new().configure(make_config(web::Data::new(app_state))),
         )
         .await;
         let req = actix_web::test::TestRequest::get()
             .uri("/status/ready")
             .to_request();
-        let resp = actix_web::test::call_service(&mut app, req).await;
+        let resp = actix_web::test::call_service(&app, req).await;
         assert_eq!(resp.status(), StatusCode::OK);
         Ok(())
     }

--- a/tagent/src/handlers.rs
+++ b/tagent/src/handlers.rs
@@ -1,7 +1,6 @@
 use actix_files::NamedFile;
 use actix_web::{
-    get, post, web, Either, Error, HttpRequest, HttpResponse, Responder,
-    ResponseError, Result,
+    get, post, web, Either, Error, HttpRequest, HttpResponse, Responder, ResponseError, Result,
 };
 use log::{debug, info};
 use std::fmt;
@@ -14,9 +13,7 @@ use futures::{StreamExt, TryStreamExt};
 use uuid::Uuid;
 
 use super::auth::get_sub;
-use super::representations::{
-    AppState, ErrorRsp, FileListingRsp, FileUploadRsp, Ready,
-};
+use super::representations::{AppState, ErrorRsp, FileListingRsp, FileUploadRsp, Ready};
 
 // status endpoints ---
 #[get("/status/ready")]
@@ -67,10 +64,7 @@ pub fn path_buf_to_string(input: PathBuf) -> Option<String> {
 
 fn path_to_string(input: &Path) -> std::io::Result<String> {
     input.to_str().map(String::from).ok_or_else(|| {
-        std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "Couldn't convert path to string",
-        )
+        std::io::Error::new(std::io::ErrorKind::Other, "Couldn't convert path to string")
     })
 }
 
@@ -128,10 +122,7 @@ pub async fn list_files_path(
     let subject = match subject {
         Ok(sub) => sub,
         Err(error) => {
-            let msg = format!(
-                "got an error from get_subject_of_request; error: {}",
-                error
-            );
+            let msg = format!("got an error from get_subject_of_request; error: {}", error);
             info!("{}", msg);
             let r = ErrorRsp {
                 status: String::from("error"),
@@ -200,10 +191,7 @@ impl ResponseError for TagentError {
     }
 }
 
-pub fn make_tagent_error(
-    message: String,
-    version: String,
-) -> Result<(), TagentError> {
+pub fn make_tagent_error(message: String, version: String) -> Result<(), TagentError> {
     let r = TagentError { message, version };
     Err(r)
 }
@@ -250,20 +238,16 @@ pub async fn get_file_contents_path(
     Ok(res)
 }
 
-pub async fn save_file(
-    mut payload: Multipart,
-    full_path: &str,
-) -> std::io::Result<()> {
+pub async fn save_file(mut payload: Multipart, full_path: &str) -> std::io::Result<()> {
     // cf., https://github.com/actix/examples/blob/master/forms/multipart/src/main.rs#L8
     // iterate over multipart stream
     while let Ok(Some(mut field)) = payload.try_next().await {
         // A multipart/form-data stream has to contain `content_disposition`
         let content_disposition = field.content_disposition();
 
-        let filename = content_disposition.get_filename().map_or_else(
-            || Uuid::new_v4().to_string(),
-            sanitize_filename::sanitize,
-        );
+        let filename = content_disposition
+            .get_filename()
+            .map_or_else(|| Uuid::new_v4().to_string(), sanitize_filename::sanitize);
 
         let filepath = format!("{}/{}", full_path, filename);
 
@@ -271,9 +255,8 @@ pub async fn save_file(
 
         // Field in turn is stream of *Bytes* object
         while let Some(chunk) = field.next().await {
-            let data = chunk.map_err(|e| {
-                std::io::Error::new(std::io::ErrorKind::Other, e.to_string())
-            })?;
+            let data =
+                chunk.map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
             f.write_all(&data).await?;
         }
     }
@@ -305,8 +288,7 @@ pub async fn post_file_contents_path(
         error = true;
     };
     if !full_path.is_dir() {
-        message =
-            format!("Invalid path; path {:?} must be a directory", full_path);
+        message = format!("Invalid path; path {:?} must be a directory", full_path);
         error = true;
     };
     if error {
@@ -388,8 +370,7 @@ mod test {
     }
 
     #[test]
-    fn get_root_dir_should_fail_if_no_vars_or_current_dir(
-    ) -> std::io::Result<()> {
+    fn get_root_dir_should_fail_if_no_vars_or_current_dir() -> std::io::Result<()> {
         std::env::remove_var("TAGENT_HOME");
         {
             let temp = tempfile::TempDir::new()?;

--- a/tagent/src/main.rs
+++ b/tagent/src/main.rs
@@ -8,9 +8,7 @@ mod handlers;
 mod models;
 mod representations;
 
-fn make_config(
-    app_data: web::Data<representations::AppState>,
-) -> impl FnOnce(&mut ServiceConfig) {
+fn make_config(app_data: web::Data<representations::AppState>) -> impl FnOnce(&mut ServiceConfig) {
     |cfg: &mut ServiceConfig| {
         cfg.app_data(app_data).service(
             //

--- a/tagent/src/main.rs
+++ b/tagent/src/main.rs
@@ -1,4 +1,5 @@
 use actix_web::middleware::Logger;
+use actix_web::web::ServiceConfig;
 use actix_web::{web, App, HttpServer};
 use dotenv::dotenv;
 
@@ -6,6 +7,28 @@ mod auth;
 mod handlers;
 mod models;
 mod representations;
+
+fn make_config(
+    app_data: web::Data<representations::AppState>,
+) -> impl FnOnce(&mut ServiceConfig) {
+    |cfg: &mut ServiceConfig| {
+        cfg.app_data(app_data).service(
+            //
+            web::scope("")
+                // status routes ----
+                .service(handlers::ready)
+                // acls routes ----
+                .service(handlers::get_all_acls)
+                .service(handlers::get_acls_for_service)
+                .service(handlers::get_acls_for_service_user)
+                .service(handlers::is_authz_service_user_path)
+                // files routes ----
+                .service(handlers::list_files_path)
+                .service(handlers::get_file_contents_path)
+                .service(handlers::post_file_contents_path),
+        );
+    }
+}
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
@@ -30,24 +53,7 @@ async fn main() -> std::io::Result<()> {
             // set up application logging
             .wrap(Logger::default())
             .wrap(Logger::new("%a %{User-Agent}i"))
-            // declare app state
-            .app_data(actix_app_state.clone())
-            // declare routes
-            .service(
-                //
-                web::scope("")
-                    // status routes ----
-                    .service(handlers::ready)
-                    // acls routes ----
-                    .service(handlers::get_all_acls)
-                    .service(handlers::get_acls_for_service)
-                    .service(handlers::get_acls_for_service_user)
-                    .service(handlers::is_authz_service_user_path)
-                    // files routes ----
-                    .service(handlers::list_files_path)
-                    .service(handlers::get_file_contents_path)
-                    .service(handlers::post_file_contents_path),
-            )
+            .configure(make_config(actix_app_state.clone()))
     })
     .bind("127.0.0.1:8080")?
     .run()


### PR DESCRIPTION
# Add test for /status/ready endpoint

This PR adds a test to exercise an endpoint. Right now it does it simply for `/status/ready` and check that the status code is 200. This was done more as a sample for future tests. A more robust test for `/status/read` should, perhaps, check the JSON value returned.

The main refactoring was to split the configuration of the `App` object to its own function, so we can generate "fake" configs and apps for using in the tests.

Try this branch with:
```
cargo test -- --test-threads=1
```
(once merged into `main` the CI/CD should run this tests automatically).
