### PR TITLE
Using max width = 80 columns for Rust fmt?

### DIFF
--- a/tagent/rustfmt.toml
+++ b/tagent/rustfmt.toml
@@ -1,1 +1,1 @@
-# max_width = 80
+max_width = 80

--- a/tagent/src/auth.rs
+++ b/tagent/src/auth.rs
@@ -79,11 +79,17 @@ async fn fetch_publickey(uri: &str) -> Result<String, String> {
 
 //get the value of a header_name from a request
 // cf., https://stackoverflow.com/questions/52919494/is-there-simpler-method-to-get-the-string-value-of-an-actix-web-http-header
-fn get_header_value<'a>(req: &'a HttpRequest, header_name: &str) -> Option<&'a str> {
+fn get_header_value<'a>(
+    req: &'a HttpRequest,
+    header_name: &str,
+) -> Option<&'a str> {
     req.headers().get(header_name)?.to_str().ok()
 }
 
-pub async fn get_sub(req: HttpRequest, pub_key: String) -> Result<String, String> {
+pub async fn get_sub(
+    req: HttpRequest,
+    pub_key: String,
+) -> Result<String, String> {
     debug!("top of get_sub");
     let token = get_header_value(&req, "x-tapis-token");
     debug!("returned from get_header_value..");

--- a/tagent/src/main.rs
+++ b/tagent/src/main.rs
@@ -8,7 +8,9 @@ mod handlers;
 mod models;
 mod representations;
 
-fn make_config(app_data: web::Data<representations::AppState>) -> impl FnOnce(&mut ServiceConfig) {
+fn make_config(
+    app_data: web::Data<representations::AppState>,
+) -> impl FnOnce(&mut ServiceConfig) {
     |cfg: &mut ServiceConfig| {
         cfg.app_data(app_data).service(
             //


### PR DESCRIPTION
# Using max width = 80 columns for Rust fmt?

⚠️ This may be very debatable ⚠️ 

⚠️ This PR should be merged **after** #9, since this branch is based in `test_endpoint` ⚠️ 

I find that using `rust-analyzer` in VSCode makes the lines very long, because it adds those (very useful) types to the arguments, lines, etc:

<img width="687" alt="Screen Shot 2022-02-13 at 11 26 50 PM" src="https://user-images.githubusercontent.com/1231439/153805650-2dac09ea-711e-4a8a-bb6b-dee20cae61a3.png">

How would you feel if we reduce the maximum width to 80 columns?  The default is 100.

