### PR TITLE
Configuration Management for Tagent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ target/
 *.pdb
 
 # End of https://www.toptal.com/developers/gitignore/api/rust
+
+.vscode/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,7 +52,7 @@ dependencies = [
  "actix-rt",
  "actix-service",
  "actix-utils",
- "ahash",
+ "ahash 0.7.6",
  "base64",
  "bitflags",
  "brotli",
@@ -74,7 +74,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rand",
- "sha-1",
+ "sha-1 0.10.0",
  "smallvec",
  "zstd",
 ]
@@ -186,7 +186,7 @@ dependencies = [
  "actix-service",
  "actix-utils",
  "actix-web-codegen",
- "ahash",
+ "ahash 0.7.6",
  "bytes",
  "cfg-if",
  "cookie",
@@ -227,6 +227,12 @@ name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
+name = "ahash"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
 
 [[package]]
 name = "ahash"
@@ -387,6 +393,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d306121baf53310a3fd342d88dc0824f6bbeace68347593658525565abee8"
 
 [[package]]
+name = "async-trait"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061a7acccaa286c011ddc30970520b98fa40e00c9d644633fb26b5fc63a265e3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -438,11 +455,23 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "block-buffer"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
+dependencies = [
+ "block-padding",
+ "byte-tools",
+ "byteorder",
+ "generic-array 0.12.4",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -451,7 +480,16 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.5",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
+dependencies = [
+ "byte-tools",
 ]
 
 [[package]]
@@ -494,6 +532,12 @@ name = "bumpalo"
 version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
+
+[[package]]
+name = "byte-tools"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
@@ -556,6 +600,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
 dependencies = [
  "cache-padded",
+]
+
+[[package]]
+name = "config"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54ad70579325f1a38ea4c13412b82241c5900700a69785d73e2736bd65a33f86"
+dependencies = [
+ "async-trait",
+ "json5",
+ "lazy_static",
+ "nom",
+ "pathdiff",
+ "ron",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "toml",
+ "yaml-rust",
 ]
 
 [[package]]
@@ -631,7 +694,7 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83bd3bb4314701c568e340cd8cf78c975aa0ca79e03d3f6d1677d5b0c9c0c03"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.5",
  "rand_core",
  "subtle",
  "zeroize",
@@ -643,7 +706,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4600d695eb3f6ce1cd44e6e291adceb2cc3ab12f20a33777ecd0bf6eba34e06"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -652,7 +715,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.5",
  "subtle",
 ]
 
@@ -697,11 +760,20 @@ dependencies = [
 
 [[package]]
 name = "digest"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
+dependencies = [
+ "generic-array 0.12.4",
+]
+
+[[package]]
+name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -712,6 +784,35 @@ checksum = "8cb780dce4f9a8f5c087362b3a4595936b2019e7c8b30f2c3e9a7e94e6ae9837"
 dependencies = [
  "block-buffer 0.10.2",
  "crypto-common",
+]
+
+[[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03d86534ed367a67548dc68113a0f5db55432fdfbb6e6f9d77704397d95d5780"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68df3f2b690c1b86e65ef7830956aededf3cb0a16f898f79b9a6f421a7b6211b"
+dependencies = [
+ "rand",
 ]
 
 [[package]]
@@ -750,7 +851,7 @@ checksum = "beca177dcb8eb540133e7680baff45e7cc4d93bf22002676cec549f82343721b"
 dependencies = [
  "crypto-bigint",
  "ff",
- "generic-array",
+ "generic-array 0.14.5",
  "group",
  "pkcs8",
  "rand_core",
@@ -785,6 +886,12 @@ name = "event-listener"
 version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77f3309417938f28bf8228fcff79a4a37103981e3e186d2ccd19c74b38f4eb71"
+
+[[package]]
+name = "fake-simd"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "fastrand"
@@ -960,6 +1067,15 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
@@ -1019,6 +1135,15 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+dependencies = [
+ "ahash 0.4.7",
 ]
 
 [[package]]
@@ -1171,7 +1296,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg 1.1.0",
- "hashbrown",
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -1211,6 +1336,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a38fc24e30fd564ce974c02bf1d337caddff65be6cc4735a1f7eab22a7440f04"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "json5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
 ]
 
 [[package]]
@@ -1285,6 +1421,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
+
+[[package]]
 name = "local-channel"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1322,6 +1464,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
 name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1348,6 +1496,12 @@ dependencies = [
  "mime",
  "unicase",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1410,6 +1564,17 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d11e1ef389c76fe5b81bcaf2ea32cf88b62bc494e19f493d0b30e7a930109"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+ "version_check",
 ]
 
 [[package]]
@@ -1497,6 +1662,12 @@ checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
 
 [[package]]
 name = "opaque-debug"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+
+[[package]]
+name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
@@ -1532,6 +1703,16 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "ordered-multimap"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c672c7ad9ec066e428c00eb917124a06f08db19e2584de982cc34b1f4c12485"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.9.1",
 ]
 
 [[package]]
@@ -1583,6 +1764,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
 
 [[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1596,6 +1783,49 @@ name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54be6e404f5317079812fc8f9f5279de376d8856929e21c184ecf6bbd692a11d"
+dependencies = [
+ "maplit",
+ "pest",
+ "sha-1 0.8.2",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1726,6 +1956,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+]
+
+[[package]]
 name = "regex"
 version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1788,6 +2028,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ron"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b861ecaade43ac97886a512b360d01d66be9f41f3c61088b42cedf92e03d678"
+dependencies = [
+ "base64",
+ "bitflags",
+ "serde",
+]
+
+[[package]]
 name = "rsa"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1805,6 +2056,16 @@ dependencies = [
  "rand",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63471c4aa97a1cf8332a5f97709a79a4234698de6a1f5087faf66f2dae810e22"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
 ]
 
 [[package]]
@@ -1922,6 +2183,18 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
+dependencies = [
+ "block-buffer 0.7.3",
+ "digest 0.8.1",
+ "fake-simd",
+ "opaque-debug 0.2.3",
+]
+
+[[package]]
+name = "sha-1"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
@@ -1941,7 +2214,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.9.0",
- "opaque-debug",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -2038,6 +2311,8 @@ dependencies = [
  "actix-rt",
  "actix-web",
  "async-std",
+ "config",
+ "dirs",
  "dotenv",
  "env_logger",
  "futures",
@@ -2170,6 +2445,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "tower-service"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2216,6 +2500,12 @@ name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unchecked-index"
@@ -2447,6 +2737,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]

--- a/settings.yaml
+++ b/settings.yaml
@@ -1,3 +1,0 @@
-foo: "hello"
-bar: "42"
-baz: "goo"

--- a/settings.yaml
+++ b/settings.yaml
@@ -1,0 +1,3 @@
+foo: "hello"
+bar: "42"
+baz: "goo"

--- a/tagent/Cargo.toml
+++ b/tagent/Cargo.toml
@@ -22,6 +22,8 @@ dotenv = "0.15"
 uuid = { version = "0.8", features = ["v4"] }
 rsa = "0.5.0"
 tempfile = "3.3.0"
+config = "0.12.0"
+dirs = "4.0.0"
 
 [dev-dependencies]
 actix-rt = "2.6.0"

--- a/tagent/src/config.rs
+++ b/tagent/src/config.rs
@@ -180,7 +180,7 @@ pub struct TagentConfig {
 impl TagentConfig {
     pub fn new() -> Result<Self, TagentError> {
         Ok(TagentConfig {
-            root_directory: dirs::home_dir().ok_or_else(|| "couldn't get user's home directory")?,
+            root_directory: dirs::home_dir().ok_or("couldn't get user's home directory")?,
             public_key: None,
             address: String::from("127.0.0.1"),
             port: 8080,
@@ -196,11 +196,11 @@ impl From<config::ConfigError> for TagentError {
 
 impl TagentConfig {
     pub fn from_sources() -> Result<Self, TagentError> {
-        let mut config = dirs::config_dir().ok_or_else(|| "couldn't get config directory")?;
+        let mut config = dirs::config_dir().ok_or("couldn't get config directory")?;
         config.push(CONFIG_FILE);
         let config_path = config
             .to_str()
-            .ok_or_else(|| "path to config file cannot be converted to string")?;
+            .ok_or("path to config file cannot be converted to string")?;
         Self::from_sources_with_names(config_path, VAR_PREFIX)
     }
 

--- a/tagent/src/config.rs
+++ b/tagent/src/config.rs
@@ -174,7 +174,7 @@ mod test {
         let key = t.get_public_key_with_default(retriever).await?;
         let components = key.to_components();
         assert_eq!(components.n[0], 157);
-        assert_eq!(components.e, vec![1,0,1]);
+        assert_eq!(components.e, vec![1, 0, 1]);
         Ok(())
     }
 

--- a/tagent/src/config.rs
+++ b/tagent/src/config.rs
@@ -22,12 +22,12 @@ struct TenantsAPIResponse {
 }
 
 /// Fetch the public key from a GET request to a uri.
-/// 
+///
 /// It returns a string containing the key in PEM format.
-/// 
+///
 /// In practice, `uri` will be the Tapis tenants API endpoint:
 /// <https://admin.tapis.io/v3/tenants/admin>.
-/// 
+///
 async fn fetch_publickey(uri: &str) -> Result<String, TagentError> {
     let res = reqwest::get(uri).await?;
     match res.status() {
@@ -92,31 +92,31 @@ fn public_key_from_pem(pem: String) -> Result<RS256PublicKey, TagentError> {
 // ========================
 
 /// Settings file.
-/// 
+///
 /// Default location for the settings file. The config directory comes from the standard
 /// location for configuration files for the OS.
-/// 
+///
 /// For example, for Linux the location is `~/.config/tagent/settings.yaml`.
-/// 
+///
 const CONFIG_FILE: &str = "tagent/settings.yaml";
 
 /// Environment variables prefix.
-/// 
+///
 /// This prefix gets added to the field names of TagentConfig to retrieve defaults from
 /// environment variables.  The environment variables override the defaults and the
 /// values from the settings file.
-/// 
+///
 /// For example, the environment variable `TAGENT_ROOT_DIRECTORY` overrides the field
 /// `root_directory` from TagentConfig defaults and from the settings file.
-/// 
+///
 const VAR_PREFIX: &str = "TAGENT";
 
 /// Configuration structure.
-/// 
+///
 /// For adding new properties:
 /// - Add a field to `TagentConfig`, and
 /// - Add a default to `TagentConfig::new()`.
-/// 
+///
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct TagentConfig {
     pub root_directory: PathBuf,
@@ -149,10 +149,10 @@ impl From<config::ConfigError> for TagentError {
 
 impl TagentConfig {
     /// Build a `TagentConfig`.
-    /// 
+    ///
     /// Exercise `from_sources_with_names` with the default values for the settings file
     /// and for the prefix of the environment variables.
-    /// 
+    ///
     pub fn from_sources() -> Result<Self, TagentError> {
         let mut config = dirs::config_dir().ok_or("couldn't get config directory")?;
         config.push(CONFIG_FILE);
@@ -163,14 +163,14 @@ impl TagentConfig {
     }
 
     /// Build a `TagentConfig`.
-    /// 
+    ///
     /// Read the following sources in order:
     /// - Defaults: from the constructor `TagentConfig::new()`,
     /// - Settings file (`file`),
     /// - Environment variables (prefixed with `var_prefix`).
-    /// 
+    ///
     /// The file and the variables are optional.
-    /// 
+    ///
     fn from_sources_with_names(file: &str, var_prefix: &str) -> Result<Self, TagentError> {
         let settings = Config::builder()
             .add_source(config::Config::try_from::<TagentConfig>(
@@ -184,19 +184,19 @@ impl TagentConfig {
     }
 
     /// Get public key.
-    /// 
+    ///
     /// Exercise `public_key_with_default`, using a function `retriever` that fetches a
     /// key from the URL specified in the field `public_key_url`.
-    /// 
+    ///
     pub async fn get_public_key(&self) -> Result<RS256PublicKey, TagentError> {
         self.get_public_key_with_default(fetch_publickey).await
     }
 
     /// Get public key.
-    /// 
+    ///
     /// Use the `public_key` field of `TagentConfig` if it is not `None`.
     /// Otherwise, use the function `retriever` to fetch a public key.
-    /// 
+    ///
     async fn get_public_key_with_default<'a, F, Fut>(
         &'a self,
         retriever: F,

--- a/tagent/src/config.rs
+++ b/tagent/src/config.rs
@@ -1,6 +1,9 @@
+use config::Config;
 use jwt_simple::algorithms::RS256PublicKey;
 use log::{debug, error, info};
 use serde::{Deserialize, Serialize};
+
+use crate::representations::TagentError;
 
 // Tapis Tenants API response structs ---
 
@@ -156,6 +159,25 @@ pub async fn get_pub_key() -> std::io::Result<RS256PublicKey> {
         }
     };
     Ok(rsa_pub_key)
+}
+
+// Configuration management
+// ========================
+
+#[derive(Deserialize, Debug)]
+pub struct TagentConfig {
+    pub foo: String,
+    pub bar: i32,
+    pub baz: Option<String>,
+}
+
+pub fn read_config() -> Result<TagentConfig, TagentError> {
+    let settings = Config::builder()
+        .add_source(config::File::with_name("settings.yaml"))
+        .add_source(config::Environment::with_prefix("TAGENT")).build().unwrap();
+    let a = settings.try_deserialize::<TagentConfig>();
+    dbg!(&a);
+    Ok(a.unwrap())
 }
 
 #[cfg(test)]

--- a/tagent/src/config.rs
+++ b/tagent/src/config.rs
@@ -164,6 +164,9 @@ pub async fn get_pub_key() -> std::io::Result<RS256PublicKey> {
 // Configuration management
 // ========================
 
+const CONFIG_FILE: &str = ".tagent.yaml";
+const VAR_PREFIX: &str = "TAGENT";
+
 #[derive(Serialize, Deserialize, Debug)]
 pub struct TagentConfig {
     pub foo: String,
@@ -190,11 +193,11 @@ impl From<config::ConfigError> for TagentError {
 impl TagentConfig {
     pub fn from_sources() -> Result<Self, TagentError> {
         let mut config = dirs::home_dir().ok_or_else(|| "couldn't get user's home directory")?;
-        config.push(".tagent.yaml");
+        config.push(CONFIG_FILE);
         let config_path = config
             .to_str()
             .ok_or_else(|| "path to config file cannot be converted to string")?;
-        Self::from_sources_with_names(config_path, "TAGENT")
+        Self::from_sources_with_names(config_path, VAR_PREFIX)
     }
 
     fn from_sources_with_names(file: &str, var_prefix: &str) -> Result<Self, TagentError> {

--- a/tagent/src/config.rs
+++ b/tagent/src/config.rs
@@ -200,7 +200,7 @@ impl TagentConfig {
     fn from_sources_with_names(file: &str, var_prefix: &str) -> Result<Self, TagentError> {
         let settings = Config::builder()
             .add_source(config::Config::try_from::<TagentConfig>(&Default::default())?)
-            .add_source(config::File::with_name(file))
+            .add_source(config::File::with_name(file).required(false))
             .add_source(config::Environment::with_prefix(var_prefix))
             .build()?
             .try_deserialize::<TagentConfig>()?;

--- a/tagent/src/handlers.rs
+++ b/tagent/src/handlers.rs
@@ -1,6 +1,6 @@
 use actix_files::NamedFile;
 use actix_web::{get, post, web, HttpRequest, HttpResponse, Responder, Result};
-use log::{debug, info, warn};
+use log::{debug, info};
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -58,26 +58,6 @@ pub fn path_buf_to_str(input: &Path) -> Option<&str> {
 // Returns None if the input is not valid UTF-8.
 pub fn path_buf_to_string(input: PathBuf) -> Option<String> {
     input.as_path().to_str().map(|s| s.to_string())
-}
-
-fn path_to_string(input: &Path) -> std::io::Result<String> {
-    input.to_str().map(String::from).ok_or_else(|| {
-        std::io::Error::new(std::io::ErrorKind::Other, "Couldn't convert path to string")
-    })
-}
-
-pub(crate) fn get_root_dir() -> std::io::Result<String> {
-    std::env::var("TAGENT_HOME")
-        .or_else( |_| {warn!("TAGENT_HOME not set; using current working directory!"); std::env::current_dir()}
-            .and_then(std::fs::canonicalize)
-            .and_then(|x| path_to_string(&x)))
-        .or_else(|_| {warn!("Couldn't use the curent working directory; defaulting to $HOME!"); std::env::var("HOME")} )
-        .map_err(|_| {
-            std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "Couldn't determine base directory.\nHelp: set the environment variable TAGENT_HOME.",
-            )
-        })
 }
 
 // files endpoints ---
@@ -271,68 +251,6 @@ mod test {
     use crate::make_config;
 
     use super::*;
-
-    #[test]
-    fn path_to_string_should_work_on_ascii() -> std::io::Result<()> {
-        let s = path_to_string(Path::new("/foo/bar"))?;
-        assert_eq!(s, "/foo/bar");
-        Ok(())
-    }
-
-    #[test]
-    fn path_to_string_should_work_on_unicode() -> std::io::Result<()> {
-        let s = path_to_string(Path::new("/\u{2122}foo/bar"))?;
-        assert_eq!(s, "/\u{2122}foo/bar");
-        Ok(())
-    }
-
-    #[test]
-    fn get_root_dir_with_tagent_home_var() -> std::io::Result<()> {
-        std::env::set_var("TAGENT_HOME", "bar");
-        let r = get_root_dir()?;
-        assert_eq!(r, "bar");
-        Ok(())
-    }
-
-    #[test]
-    fn get_root_dir_with_current_dir() -> std::io::Result<()> {
-        let temp = tempfile::TempDir::new()?;
-        std::env::set_current_dir(&temp)?;
-        std::env::remove_var("TAGENT_HOME");
-        let r = get_root_dir()?;
-        assert_eq!(r, std::fs::canonicalize(temp)?.to_str().unwrap());
-        Ok(())
-    }
-
-    #[test]
-    fn get_root_dir_with_user_home() -> std::io::Result<()> {
-        std::env::remove_var("TAGENT_HOME");
-        {
-            let temp = tempfile::TempDir::new()?;
-            std::env::set_current_dir(temp)?;
-            // temp gets deleted when going out of scope, so
-            // current_dir becomes invalid
-        }
-        std::env::set_var("HOME", "baz");
-        let a = get_root_dir()?;
-        assert_eq!(a, "baz");
-        Ok(())
-    }
-
-    #[test]
-    fn get_root_dir_should_fail_if_no_vars_or_current_dir() -> std::io::Result<()> {
-        std::env::remove_var("TAGENT_HOME");
-        {
-            let temp = tempfile::TempDir::new()?;
-            std::env::set_current_dir(temp)?;
-            // temp gets deleted when going out of scope, so
-            // current_dir becomes invalid
-        }
-        std::env::remove_var("HOME");
-        let a = get_root_dir();
-        assert!(a.is_err());
-        Ok(())
-    }
 
     #[actix_rt::test]
     async fn status_should_be_ready() -> std::io::Result<()> {

--- a/tagent/src/handlers.rs
+++ b/tagent/src/handlers.rs
@@ -339,7 +339,7 @@ mod test {
         let pub_str = String::from("-----BEGIN RSA PUBLIC KEY-----\nMIIBCgKCAQEAtsQsUV8QpqrygsY+2+JCQ6Fw8/omM71IM2N/R8pPbzbgOl0p78MZ\nGsgPOQ2HSznjD0FPzsH8oO2B5Uftws04LHb2HJAYlz25+lN5cqfHAfa3fgmC38Ff\nwBkn7l582UtPWZ/wcBOnyCgb3yLcvJrXyrt8QxHJgvWO23ITrUVYszImbXQ67YGS\n0YhMrbixRzmo2tpm3JcIBtnHrEUMsT0NfFdfsZhTT8YbxBvA8FdODgEwx7u/vf3J\n9qbi4+Kv8cvqyJuleIRSjVXPsIMnoejIn04APPKIjpMyQdnWlby7rNyQtE4+CV+j\ncFjqJbE/Xilcvqxt6DirjFCvYeKYl1uHLwIDAQAB\n-----END RSA PUBLIC KEY-----");
         let app_state = AppState {
             app_version: String::from("0.1.0"),
-            root_dir: String::from(""),
+            root_dir: PathBuf::from(""),
             pub_key: RS256PublicKey::from_pem(&pub_str).unwrap(),
         };
         let app = actix_web::test::init_service(

--- a/tagent/src/main.rs
+++ b/tagent/src/main.rs
@@ -32,15 +32,14 @@ fn make_config(app_data: web::Data<representations::AppState>) -> impl FnOnce(&m
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-    let settings = crate::config::TagentConfig::from_sources().unwrap();
-    dbg!(settings);
+    let settings = crate::config::TagentConfig::from_sources()?;
     dotenv().ok();
     env_logger::init();
 
     let app_version = String::from(env!("CARGO_PKG_VERSION"));
-    let root_dir = handlers::get_root_dir()?;
+    let root_dir = settings.root_directory;
     info!("tagent version {}", app_version);
-    info!("tagent running with root directory: {}", root_dir);
+    info!("tagent running with root directory: {:?}", &root_dir);
     // let pub_key = String::from("-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAieWoWm/7AZPheleSJSXR/CS9vnr2m7qsjzvqv7PXr5AOxpw+eYn5h1/7lBqludzle4fI8ai/mv2WsTEC7C3HuIF5D+EuCQtXe89YPI8e4Q/gc660vWhG3ZYA5UrZyAOAJvDvcd/N8ZCjyW8fZ5tYsMlcWf6m9d29QLtLc8kIIZJiFuQcfiq5NiaB5tYU6zOQzO6fYUO44egni1DH6spm0btqobIsNQauunXSuZD3lLwXGnuS1VE+3pPEIFeAq0tnQcuJxsUZIRbiWRgAnNHCFoxeB3kMysKUr1IMjqlUlTBgDbCvfn8RJxQUeMgEJygsa/m9xHzfX3IoAm4NfvsEPwIDAQAB\n-----END PUBLIC KEY-----");
     let pub_key = config::get_pub_key().await?;
     let app_state = representations::AppState {
@@ -59,7 +58,7 @@ async fn main() -> std::io::Result<()> {
             .wrap(Logger::new("%a %{User-Agent}i"))
             .configure(make_config(actix_app_state.clone()))
     })
-    .bind("127.0.0.1:8080")?
+    .bind(format!("{}:{}", settings.address, settings.port))?
     .run()
     .await
 }

--- a/tagent/src/main.rs
+++ b/tagent/src/main.rs
@@ -32,6 +32,9 @@ fn make_config(app_data: web::Data<representations::AppState>) -> impl FnOnce(&m
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
+    dbg!(std::env::current_dir());
+    config::read_config();
+
     dotenv().ok();
     env_logger::init();
 

--- a/tagent/src/main.rs
+++ b/tagent/src/main.rs
@@ -32,16 +32,15 @@ fn make_config(app_data: web::Data<representations::AppState>) -> impl FnOnce(&m
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-    let settings = crate::config::TagentConfig::from_sources()?;
     dotenv().ok();
     env_logger::init();
 
+    let settings = crate::config::TagentConfig::from_sources()?;
     let app_version = String::from(env!("CARGO_PKG_VERSION"));
-    let root_dir = settings.root_directory;
+    let root_dir = settings.root_directory.clone();
     info!("tagent version {}", app_version);
     info!("tagent running with root directory: {:?}", &root_dir);
-    // let pub_key = String::from("-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAieWoWm/7AZPheleSJSXR/CS9vnr2m7qsjzvqv7PXr5AOxpw+eYn5h1/7lBqludzle4fI8ai/mv2WsTEC7C3HuIF5D+EuCQtXe89YPI8e4Q/gc660vWhG3ZYA5UrZyAOAJvDvcd/N8ZCjyW8fZ5tYsMlcWf6m9d29QLtLc8kIIZJiFuQcfiq5NiaB5tYU6zOQzO6fYUO44egni1DH6spm0btqobIsNQauunXSuZD3lLwXGnuS1VE+3pPEIFeAq0tnQcuJxsUZIRbiWRgAnNHCFoxeB3kMysKUr1IMjqlUlTBgDbCvfn8RJxQUeMgEJygsa/m9xHzfX3IoAm4NfvsEPwIDAQAB\n-----END PUBLIC KEY-----");
-    let pub_key = config::get_pub_key().await?;
+    let pub_key = settings.get_public_key().await?;
     let app_state = representations::AppState {
         app_version,
         root_dir,

--- a/tagent/src/main.rs
+++ b/tagent/src/main.rs
@@ -35,8 +35,9 @@ async fn main() -> std::io::Result<()> {
     dotenv().ok();
     env_logger::init();
 
-    let app_version = String::from("0.1.0");
+    let app_version = String::from(env!("CARGO_PKG_VERSION"));
     let root_dir = handlers::get_root_dir()?;
+    info!("tagent version {}", app_version);
     info!("tagent running with root directory: {}", root_dir);
     // let pub_key = String::from("-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAieWoWm/7AZPheleSJSXR/CS9vnr2m7qsjzvqv7PXr5AOxpw+eYn5h1/7lBqludzle4fI8ai/mv2WsTEC7C3HuIF5D+EuCQtXe89YPI8e4Q/gc660vWhG3ZYA5UrZyAOAJvDvcd/N8ZCjyW8fZ5tYsMlcWf6m9d29QLtLc8kIIZJiFuQcfiq5NiaB5tYU6zOQzO6fYUO44egni1DH6spm0btqobIsNQauunXSuZD3lLwXGnuS1VE+3pPEIFeAq0tnQcuJxsUZIRbiWRgAnNHCFoxeB3kMysKUr1IMjqlUlTBgDbCvfn8RJxQUeMgEJygsa/m9xHzfX3IoAm4NfvsEPwIDAQAB\n-----END PUBLIC KEY-----");
     let pub_key = config::get_pub_key().await?;

--- a/tagent/src/main.rs
+++ b/tagent/src/main.rs
@@ -32,9 +32,8 @@ fn make_config(app_data: web::Data<representations::AppState>) -> impl FnOnce(&m
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-    dbg!(std::env::current_dir());
-    config::read_config();
-
+    let settings = crate::config::TagentConfig::from_sources().unwrap();
+    dbg!(settings);
     dotenv().ok();
     env_logger::init();
 

--- a/tagent/src/main.rs
+++ b/tagent/src/main.rs
@@ -40,6 +40,7 @@ async fn main() -> std::io::Result<()> {
     let root_dir = settings.root_directory.clone();
     info!("tagent version {}", app_version);
     info!("tagent running with root directory: {:?}", &root_dir);
+    info!("tagent serving at {}:{}", settings.address, settings.port);
     let pub_key = settings.get_public_key().await?;
     let app_state = representations::AppState {
         app_version,

--- a/tagent/src/representations.rs
+++ b/tagent/src/representations.rs
@@ -42,7 +42,7 @@ pub struct FileUploadRsp {
 }
 
 // The Error type that can convert to a actix_web::HttpResponse
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct TagentError {
     message: String,
     version: String,

--- a/tagent/src/representations.rs
+++ b/tagent/src/representations.rs
@@ -1,11 +1,11 @@
 use actix_web::{HttpResponse, ResponseError};
 use jwt_simple::algorithms::RS256PublicKey;
 use serde::Serialize;
-use std::fmt;
+use std::{fmt, path::PathBuf};
 
 pub struct AppState {
     pub app_version: String,
-    pub root_dir: String,
+    pub root_dir: PathBuf,
     pub pub_key: RS256PublicKey,
 }
 
@@ -61,6 +61,18 @@ impl TagentError {
 impl From<&str> for TagentError {
     fn from(message: &str) -> Self {
         TagentError::new_with_version(String::from(message))
+    }
+}
+
+impl From<TagentError> for std::io::Error {
+    fn from(tagent_error: TagentError) -> Self {
+        std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!(
+                "TagentError (version: {}): {}",
+                tagent_error.message, tagent_error.version
+            ),
+        )
     }
 }
 

--- a/tagent/src/representations.rs
+++ b/tagent/src/representations.rs
@@ -64,6 +64,12 @@ impl From<&str> for TagentError {
     }
 }
 
+impl From<String> for TagentError {
+    fn from(message: String) -> Self {
+        TagentError::new_with_version(message)
+    }
+}
+
 impl From<TagentError> for std::io::Error {
     fn from(tagent_error: TagentError) -> Self {
         std::io::Error::new(
@@ -73,6 +79,18 @@ impl From<TagentError> for std::io::Error {
                 tagent_error.message, tagent_error.version
             ),
         )
+    }
+}
+
+impl From<std::io::Error> for TagentError {
+    fn from(error: std::io::Error) -> Self {
+        TagentError::new_with_version(format!("IO Error: {}", error))
+    }
+}
+
+impl From<reqwest::Error> for TagentError {
+    fn from(error: reqwest::Error) -> Self {
+        TagentError::new_with_version(format!("Request Error: {}", error))
     }
 }
 

--- a/tagent/src/representations.rs
+++ b/tagent/src/representations.rs
@@ -52,6 +52,16 @@ impl TagentError {
     pub fn new(message: String, version: String) -> Self {
         TagentError { message, version }
     }
+
+    pub fn new_with_version(message: String) -> Self {
+        Self::new(message, String::from(env!("CARGO_PKG_VERSION")))
+    }
+}
+
+impl From<&str> for TagentError {
+    fn from(message: &str) -> Self {
+        TagentError::new_with_version(String::from(message))
+    }
 }
 
 impl fmt::Display for TagentError {


### PR DESCRIPTION
# Configuration Management for Tagent

Implement an strategy to have hardcoded defaults (so tagent can work out of the box), and reading environment variables, and a file, for extra configuration.

The configuration file goes in the config directory (`~/.config/tagent/settings.yaml` for Linux, `~/Library/Application Support/tagent/settings.yaml` for Mac, and who knows for Windows...).

Right now the options are:
```yaml
root_directory: ""  # default to $HOME
public_key: ""      # default to None
address:  ""        # default to 127.0.0.1
port: 8080          # default to 8080
```
The values can be overriden with enviroment variables of the form `TAGENT_ROOT_DIRECTORY=...`.

Adding a new configuration property to the code, involves updating the struct `config::TagentConfig` and adding a default value to the implementation of `config::TagentConfig::new()`. No other changes are required.

## TO DO

- [x] Read public key from config system
- [x] Comment code
- [x] Add tests for `TagentConfig::from_sources_with_names`.